### PR TITLE
Fix test suite to work with Python 3

### DIFF
--- a/path_and_address/tests/test_parsing.py
+++ b/path_and_address/tests/test_parsing.py
@@ -1,6 +1,9 @@
 from itertools import product
+import sys
 from ..parsing import resolve, split_address
 
+if sys.version_info[0] >= 3:
+    basestring = str
 
 paths = [
     '0.0.0.0',

--- a/path_and_address/tests/test_validation.py
+++ b/path_and_address/tests/test_validation.py
@@ -7,7 +7,7 @@ def _join(host_and_port):
 
 
 def _join_all(hostnames, ports):
-    return map(_join, product(hostnames, ports))
+    return list(map(_join, product(hostnames, ports)))
 
 
 hostnames = [


### PR DESCRIPTION
Hey Joe,

I've fixed the following items:
- In Python 3, `map()` returns a map object, not a list, making the test fail with `TypeError: can only concatenate list (not`map`) to list`.
- Python 3 doesn't have `basestring`, which was making another test fail.

This closes the issue #1.

I can send another PR adding Travis support if you like.

Regards,
Tiago.
