### PR TITLE
Fix incorrect of use of parentheses in assert statements

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -81,5 +81,5 @@ def test_split_address():
         if isinstance(p, basestring):
             p = str(p).replace(':', '')
         host, port = split_address('%s:%s' % (h, p))
-        assert (str(host) == str(h) and str(port) == str(p),
+        assert str(host) == str(h) and str(port) == str(p), (
                 'Expected %s, got %s' % (repr((h, p)), repr((host, port))))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -45,29 +45,29 @@ invalid_addresses = (
 
 def test_valid_address():
     for address in addresses:
-        assert (valid_address(address),
+        assert valid_address(address), (
                 'Invalid address, expected to be valid: ' + repr(address))
 
     for address in invalid_addresses:
-        assert (not valid_address(address),
+        assert not valid_address(address), (
                 'Valid address, expected to be invalid: ' + repr(address))
 
 
 def test_valid_hostname():
     for hostname in hostnames:
-        assert (valid_hostname(hostname),
+        assert valid_hostname(hostname), (
                 'Invalid hostname, expected to be valid: ' + repr(hostname))
 
     for hostname in invalid_hostnames:
-        assert (not valid_hostname(hostname),
+        assert not valid_hostname(hostname), (
                 'Valid hostname, expected to be invalid: ' + repr(hostname))
 
 
 def test_valid_port():
     for port in ports:
-        assert (valid_port(port),
+        assert valid_port(port), (
                 'Invalid port, expected to be valid: ' + repr(port))
 
     for port in invalid_ports:
-        assert (not valid_port(port),
+        assert not valid_port(port), (
                 'Valid port, expected to be invalid: ' + repr(port))


### PR DESCRIPTION
It's a mistake to write code like this:
```python
    assert(x > 0, "x must be positive")  # wrong!
```
The intention was to check whether `x > 0` is true. But this code checks if the tuple is true, and it always is, regardless of the value of `x`. The correct code omits the parentheses:
```python
    assert x > 0, "x must be positive"
```

Found using [pydiatra](https://github.com/jwilk/pydiatra).